### PR TITLE
Hook up PEM file support.

### DIFF
--- a/res/com/dfbnc/defaults.config
+++ b/res/com/dfbnc/defaults.config
@@ -70,6 +70,9 @@ irc:
     lastKnownChannels=
 
 ssl:
+    source=keystore
     storepass=
     keypass=
     keystore=
+    certificatefile=
+    privatekeyfile=

--- a/src/com/dfbnc/DFBnc.java
+++ b/src/com/dfbnc/DFBnc.java
@@ -386,7 +386,16 @@ public class DFBnc implements NewSocketReadyHandler {
         final List<String> listenhosts = config.getOptionList("general", "listenhost");
 
         if (sslContextManager == null) {
-            sslContextManager = new SSLContextManager(getConfig().getOption("ssl", "keystore"), getConfig().getOption("ssl", "storepass"), getConfig().getOption("ssl", "keypass"));
+            if ("pem".equalsIgnoreCase(getConfig().getOption("ssl", "source"))) {
+                sslContextManager = new SSLContextManager(
+                        getConfig().getOption("ssl", "certificatefile"),
+                        getConfig().getOption("ssl", "privatekeyfile"));
+            } else {
+                sslContextManager = new SSLContextManager(
+                        getConfig().getOption("ssl", "keystore"),
+                        getConfig().getOption("ssl", "storepass"),
+                        getConfig().getOption("ssl", "keypass"));
+            }
         }
 
         for (String listenhost : listenhosts) {


### PR DESCRIPTION
If ssl.source is set to "pem", then SSL materiel will be loaded
from the files specified in ssl.certificatefile and ssl.privatekeyfile.

ssl.source defaults to "keystore", but any other unknown value
will also fallback to "keystore".

Issue #108