### PR TITLE
Update dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ MAINTAINER Shane Mc Cormack <dataforce@dataforce.org.uk>
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
+ENV JAVA_TOOL_OPTIONS -Dfile.encoding=UTF8
 
 COPY . /dfbnc/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jdk
+FROM openjdk:8-jdk
 MAINTAINER Shane Mc Cormack <dataforce@dataforce.org.uk>
 
 ENV LANG en_US.UTF-8


### PR DESCRIPTION
Switch the base image to one that receives security updates(!)

Throw some more UTF8 options at javac to stop it complaining

@ShaneMcC You'll need to change the build settings on docker hub to trigger a build when openjdk is built instead of java (build settings->repistory links)